### PR TITLE
Fix a bug: when Controller has no functions, get a wrong view name

### DIFF
--- a/cake2.el
+++ b/cake2.el
@@ -359,12 +359,16 @@
     (string-match cake2-controller-regexp (buffer-file-name))
     (setq cake2-plural-name (match-string 1 (buffer-file-name)))
     (save-excursion
-      (if
-          (not (re-search-backward "function[ \t]*\\([a-zA-Z0-9_]+\\)[ \t]*\(" nil t))
-          (re-search-forward "function[ \t]*\\([a-zA-Z0-9_]+\\)[ \t]*\(" nil t)))
-    (setq cake2-action-name (match-string 1))
-    (setq cake2-lower-camelized-action-name (cake2-lower-camelize cake2-action-name))
-    (setq cake2-snake-action-name (cake2-snake cake2-action-name))
+      (if (cond
+	   ((re-search-backward "function[ \t]*\\([a-zA-Z0-9_]+\\)[ \t]*\(" nil t))
+	   ((re-search-forward "function[ \t]*\\([a-zA-Z0-9_]+\\)[ \t]*\(" nil t)))
+	  (progn
+	    (setq cake2-action-name (match-string 1))
+	    (setq cake2-lower-camelized-action-name (cake2-lower-camelize cake2-action-name))
+	    (setq cake2-snake-action-name (cake2-snake cake2-action-name)))
+	(setq cake2-action-name nil)
+	(setq cake2-lower-camelized-action-name nil)
+	(setq cake2-snake-action-name nil)))
     (setq cake2-singular-name (cake2-singularize cake2-plural-name))
     (setq cake2-camelize-name (cake2-camelize (cake2-snake cake2-singular-name)))
     (setq cake2-current-file-type 'controller)))
@@ -506,7 +510,8 @@
   "Switch to view."
   (interactive)
   (let ((view-files nil))
-    (if (cake2-is-file)
+    (if (and (cake2-is-file)
+	     cake2-action-name)
         (progn
           (if (cake2-is-model-file)
               (setq cake2-plural-name (cake2-pluralize cake2-singular-name)))


### PR DESCRIPTION
When a Controller has no functions, "cake2-switch-to-view" create a view file with wrong filename.
- Exmaple

```
<?php

class SamplesController extends AppController {


}
```

In this situation,  a view file named "pContro.ctp" was created. 
- Emacs environment:
  - OS X Lion
  - GNU Emacs 24.0.93.1 (i386-apple-darwin11.2.0, NS apple-appkit-1138.23) of 2012-01-30 on bespin.local
